### PR TITLE
docs: add commit prefix guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,19 @@
+# Contribuer
+
+## Convention de commits
+
+Tous les messages de commit doivent commencer par l'un des préfixes suivants :
+
+- `feat:` : nouvelle fonctionnalité
+- `fix:` : correction de bug
+- `docs:` : documentation
+- `refactor:` : refactorisation du code
+- `test:` : ajout ou modification de tests
+
+Exemple :
+
+```text
+docs: documenter les préfixes de commits
+```
+
+Respecter cette convention permet d'assurer un historique Git clair et cohérent.


### PR DESCRIPTION
## Summary
- add CONTRIBUTING guide with commit message prefixes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a71b649db48324a4362e85a973a045