### PR TITLE
feat: add package entry points

### DIFF
--- a/src/predict/__main__.py
+++ b/src/predict/__main__.py
@@ -1,0 +1,24 @@
+"""Command-line entry point for the predict package."""
+
+from __future__ import annotations
+
+import argparse
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Return an argument parser for the prediction command."""
+    parser = argparse.ArgumentParser(description="Predict a car price from mileage")
+    parser.add_argument("--km", type=float, help="mileage in kilometers")
+    parser.add_argument("--theta", help="path to theta JSON", default="theta.json")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Parse arguments and run the prediction stub."""
+    _ = build_parser().parse_args(argv)
+    print("prediction routine not yet implemented")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - module glue
+    raise SystemExit(main())

--- a/src/train/__main__.py
+++ b/src/train/__main__.py
@@ -1,0 +1,26 @@
+"""Command-line entry point for the train package."""
+
+from __future__ import annotations
+
+import argparse
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Return an argument parser for the training command."""
+    parser = argparse.ArgumentParser(description="Train the linear regression model")
+    parser.add_argument("--data", help="path to training data CSV")
+    parser.add_argument("--alpha", type=float, help="learning rate")
+    parser.add_argument("--iters", type=int, help="number of iterations")
+    parser.add_argument("--theta", help="path to theta JSON", default="theta.json")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Parse arguments and run the training stub."""
+    _ = build_parser().parse_args(argv)
+    print("training routine not yet implemented")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - module glue
+    raise SystemExit(main())

--- a/tests/test_main_modules.py
+++ b/tests/test_main_modules.py
@@ -1,0 +1,21 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from predict.__main__ import main as predict_main  # noqa: E402
+from train.__main__ import main as train_main  # noqa: E402
+
+
+def test_train_main_runs(capsys: pytest.CaptureFixture[str]) -> None:
+    assert train_main([]) == 0
+    captured = capsys.readouterr()
+    assert "not yet implemented" in captured.out.lower()
+
+
+def test_predict_main_runs(capsys: pytest.CaptureFixture[str]) -> None:
+    assert predict_main([]) == 0
+    captured = capsys.readouterr()
+    assert "not yet implemented" in captured.out.lower()


### PR DESCRIPTION
## Summary
- add CLI entrypoints for train and predict packages
- cover new entrypoints with basic tests

## Testing
- `poetry run ruff check src/train/__main__.py src/predict/__main__.py tests/test_main_modules.py`
- `poetry run mypy src/train/__main__.py src/predict/__main__.py tests/test_main_modules.py`
- `poetry run pytest -q`
- `poetry run coverage run -m pytest`
- `poetry run coverage report -m`


------
https://chatgpt.com/codex/tasks/task_e_68a9dd4d7f2083248f1a383bf576e32c