### PR TITLE
feat: add validations and warnings

### DIFF
--- a/src/predict/predict.py
+++ b/src/predict/predict.py
@@ -19,24 +19,36 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def parse_args(argv: list[str] | None = None) -> tuple[float | None, str]:
+def parse_args(argv: list[str] | None = None) -> tuple[float, str]:
     """Parse CLI arguments and prompt for mileage if needed."""
+
     args = build_parser().parse_args(argv)
     km = args.km
+    if km is not None and km < 0:
+        print("ERROR: invalid mileage (must be a non-negative number)")
+        raise SystemExit(2)
     if km is None and argv is None:
         while True:
             try:
                 km = float(input("Enter mileage: "))
-                break
             except ValueError:
                 print("Invalid mileage. Please enter a number.")
+                continue
+            if km < 0:
+                print("Invalid mileage. Must be a non-negative number.")
+                continue
+            break
+    if km is None:
+        km = 0.0
     return km, args.theta
 
 
-def load_theta(path: str) -> tuple[float, float]:
-    """Return ``(theta0, theta1)`` from ``path``.
+def load_theta(
+    path: str,
+) -> tuple[float, float, float | None, float | None, float | None, float | None]:
+    """Return training coefficients and data bounds from ``path``.
 
-    If the file cannot be read or contains invalid JSON, an error message is
+    If the file cannot be read or contains invalid values, an error message is
     printed and the program exits with code ``2``.
     """
 
@@ -44,18 +56,58 @@ def load_theta(path: str) -> tuple[float, float]:
     try:
         data = json.loads(theta_path.read_text())
     except (OSError, json.JSONDecodeError):
-        print("ERROR: theta file not found")
+        print(f"ERROR: theta file not found: {theta_path}")
         raise SystemExit(2)
-    return float(data.get("theta0", 0.0)), float(data.get("theta1", 0.0))
+    try:
+        theta0 = float(data.get("theta0", 0.0))
+        theta1 = float(data.get("theta1", 0.0))
+        min_km = data.get("min_km")
+        max_km = data.get("max_km")
+        min_price = data.get("min_price")
+        max_price = data.get("max_price")
+        if min_km is not None:
+            min_km = float(min_km)
+        if max_km is not None:
+            max_km = float(max_km)
+        if min_price is not None:
+            min_price = float(min_price)
+        if max_price is not None:
+            max_price = float(max_price)
+    except (TypeError, ValueError):
+        print(f"ERROR: invalid theta values in {theta_path}")
+        raise SystemExit(2)
+    return theta0, theta1, min_km, max_km, min_price, max_price
 
 
 def predict_price(km: float, theta_path: str = "theta.json") -> float:
     """Predict the car price for ``km`` using coefficients from ``theta_path``."""
 
-    theta0, theta1 = load_theta(theta_path)
+    (
+        theta0,
+        theta1,
+        min_km,
+        max_km,
+        min_price,
+        max_price,
+    ) = load_theta(theta_path)
     if theta0 == 0.0 and theta1 == 0.0:
         return 0.0
-    return estimatePrice(km, theta0, theta1)
+    price = estimatePrice(km, theta0, theta1)
+    if (
+        min_km is not None
+        and max_km is not None
+        and not (min_km <= km <= max_km)
+    ):
+        print(f"WARNING: mileage {km} outside data range [{min_km}, {max_km}]")
+    if (
+        min_price is not None
+        and max_price is not None
+        and not (min_price <= price <= max_price)
+    ):
+        print(
+            f"WARNING: price {price} outside data range [{min_price}, {max_price}]"
+        )
+    return price
 
 
 __all__ = ["build_parser", "parse_args", "load_theta", "predict_price"]

--- a/src/train/__main__.py
+++ b/src/train/__main__.py
@@ -27,6 +27,20 @@ def _alpha_type(value: str) -> float:
     return alpha
 
 
+def _iters_type(value: str) -> int:
+    """Return ``value`` as a positive integer."""
+
+    try:
+        iters = int(value)
+    except ValueError as exc:  # pragma: no cover - argparse shows the message
+        raise argparse.ArgumentTypeError(
+            "iters must be a positive integer"
+        ) from exc
+    if iters <= 0:
+        raise argparse.ArgumentTypeError("iters must be a positive integer")
+    return iters
+
+
 def build_parser() -> argparse.ArgumentParser:  # pragma: no mutate
     """Return an argument parser for the training command."""
 
@@ -46,7 +60,7 @@ def build_parser() -> argparse.ArgumentParser:  # pragma: no mutate
     )  # pragma: no mutate
     parser.add_argument(
         "--iters",
-        type=int,
+        type=_iters_type,
         default=1000,
         help="number of iterations",
     )  # pragma: no mutate
@@ -68,7 +82,16 @@ def main(argv: list[str] | None = None) -> int:  # pragma: no mutate
         print(f"ERROR: {exc}")
         return 2
     theta0, theta1 = gradient_descent(data, args.alpha, args.iters)
-    save_theta(theta0, theta1, args.theta)
+    kms, prices = zip(*data)
+    save_theta(
+        theta0,
+        theta1,
+        args.theta,
+        min(kms),
+        max(kms),
+        min(prices),
+        max(prices),
+    )
     return 0
 
 

--- a/src/train/__main__.py
+++ b/src/train/__main__.py
@@ -33,9 +33,7 @@ def _iters_type(value: str) -> int:
     try:
         iters = int(value)
     except ValueError as exc:  # pragma: no cover - argparse shows the message
-        raise argparse.ArgumentTypeError(
-            "iters must be a positive integer"
-        ) from exc
+        raise argparse.ArgumentTypeError("iters must be a positive integer") from exc
     if iters <= 0:
         raise argparse.ArgumentTypeError("iters must be a positive integer")
     return iters

--- a/src/train/train.py
+++ b/src/train/train.py
@@ -90,16 +90,17 @@ def save_theta(
     """Write training results and data bounds as JSON to ``path``."""
 
     theta_path = Path(path)
-    data = {"theta0": theta0, "theta1": theta1}
-    if None not in (min_km, max_km, min_price, max_price):
-        data.update(
-            {
-                "min_km": min_km,
-                "max_km": max_km,
-                "min_price": min_price,
-                "max_price": max_price,
-            }
-        )
+    data: dict[str, float] = {"theta0": float(theta0), "theta1": float(theta1)}
+    bounds: dict[str, float] = {}
+    for key, value in [
+        ("min_km", min_km),
+        ("max_km", max_km),
+        ("min_price", min_price),
+        ("max_price", max_price),
+    ]:
+        if value is not None:
+            bounds[key] = float(value)
+    data.update(bounds)
     theta_path.write_text(json.dumps(data))
 
 

--- a/src/train/train.py
+++ b/src/train/train.py
@@ -25,7 +25,13 @@ def _parse_row(row: dict[str, str | None], line_number: int) -> tuple[float, flo
     price_str = row.get("price")
     if km_str is None or price_str is None:
         raise ValueError(f"invalid row {line_number}: missing value")
-    return _float_field(km_str, line_number), _float_field(price_str, line_number)
+    km = _float_field(km_str, line_number)
+    price = _float_field(price_str, line_number)
+    if km < 0:
+        raise ValueError(f"invalid row {line_number}: negative km")
+    if price < 0:
+        raise ValueError(f"invalid row {line_number}: negative price")
+    return km, price
 
 
 def read_data(path: str | Path) -> list[tuple[float, float]]:
@@ -72,11 +78,29 @@ def gradient_descent(
     return theta0, theta1
 
 
-def save_theta(theta0: float, theta1: float, path: str | Path) -> None:
-    """Write ``theta0`` and ``theta1`` as JSON to ``path``."""
+def save_theta(
+    theta0: float,
+    theta1: float,
+    path: str | Path,
+    min_km: float | None = None,
+    max_km: float | None = None,
+    min_price: float | None = None,
+    max_price: float | None = None,
+) -> None:
+    """Write training results and data bounds as JSON to ``path``."""
 
     theta_path = Path(path)
-    theta_path.write_text(json.dumps({"theta0": theta0, "theta1": theta1}))
+    data = {"theta0": theta0, "theta1": theta1}
+    if None not in (min_km, max_km, min_price, max_price):
+        data.update(
+            {
+                "min_km": min_km,
+                "max_km": max_km,
+                "min_price": min_price,
+                "max_price": max_price,
+            }
+        )
+    theta_path.write_text(json.dumps(data))
 
 
 __all__ = ["read_data", "gradient_descent", "save_theta"]

--- a/src/viz.py
+++ b/src/viz.py
@@ -44,7 +44,7 @@ def main(argv: list[str] | None = None) -> None:
 
     args = _build_parser().parse_args(argv)
     data = read_data(Path(args.data))
-    theta0, theta1 = load_theta(args.theta)
+    theta0, theta1, *_ = load_theta(args.theta)
 
     xs = [x for x, _ in data]
     ys = [y for _, y in data]

--- a/tests/test_gradient_descent.py
+++ b/tests/test_gradient_descent.py
@@ -16,3 +16,36 @@ def test_gradient_descent_and_save(tmp_path: Path) -> None:
     content = json.loads(theta_path.read_text())
     assert content["theta0"] == pytest.approx(theta0)
     assert content["theta1"] == pytest.approx(theta1)
+
+
+def test_save_theta_with_bounds(tmp_path: Path) -> None:
+    theta_path = tmp_path / "theta.json"
+    save_theta(
+        1.0,
+        2.0,
+        theta_path,
+        0.0,
+        10.0,
+        100.0,
+        200.0,
+    )
+    content = json.loads(theta_path.read_text())
+    assert content == {
+        "theta0": pytest.approx(1.0),
+        "theta1": pytest.approx(2.0),
+        "min_km": pytest.approx(0.0),
+        "max_km": pytest.approx(10.0),
+        "min_price": pytest.approx(100.0),
+        "max_price": pytest.approx(200.0),
+    }
+
+
+def test_save_theta_omits_none_bounds(tmp_path: Path) -> None:
+    theta_path = tmp_path / "theta.json"
+    save_theta(1.0, 2.0, theta_path, min_km=0.0)
+    content = json.loads(theta_path.read_text())
+    assert content == {
+        "theta0": pytest.approx(1.0),
+        "theta1": pytest.approx(2.0),
+        "min_km": pytest.approx(0.0),
+    }

--- a/tests/test_main_modules.py
+++ b/tests/test_main_modules.py
@@ -32,6 +32,10 @@ def test_train_main_runs(tmp_path: Path) -> None:
     result = json.loads(theta.read_text())
     assert result["theta0"] == pytest.approx(0.1)
     assert result["theta1"] == pytest.approx(0.1)
+    assert result["min_km"] == pytest.approx(1.0)
+    assert result["max_km"] == pytest.approx(1.0)
+    assert result["min_price"] == pytest.approx(1.0)
+    assert result["max_price"] == pytest.approx(1.0)
 
 
 def test_predict_main_runs(capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/test_predict_logic.py
+++ b/tests/test_predict_logic.py
@@ -13,18 +13,24 @@ def test_load_theta_missing_and_predict(
     with pytest.raises(SystemExit) as exc:
         load_theta(str(theta_path))
     assert exc.value.code == 2
-    assert capsys.readouterr().out.strip() == "ERROR: theta file not found"
+    assert (
+        capsys.readouterr().out.strip()
+        == f"ERROR: theta file not found: {theta_path}"
+    )
 
     with pytest.raises(SystemExit) as exc2:
         predict_price(123.0, str(theta_path))
     assert exc2.value.code == 2
-    assert capsys.readouterr().out.strip() == "ERROR: theta file not found"
+    assert (
+        capsys.readouterr().out.strip()
+        == f"ERROR: theta file not found: {theta_path}"
+    )
 
 
 def test_predict_price_with_file(tmp_path: Path) -> None:
     theta_path = tmp_path / "theta.json"
     theta_path.write_text(json.dumps({"theta0": 1.5, "theta1": 2.0}))
-    theta0, theta1 = load_theta(str(theta_path))
+    theta0, theta1, *_ = load_theta(str(theta_path))
     assert theta0 == pytest.approx(1.5)
     assert theta1 == pytest.approx(2.0)
     assert predict_price(3.0, str(theta_path)) == pytest.approx(1.5 + 2.0 * 3.0)
@@ -38,15 +44,18 @@ def test_load_theta_invalid_json(
     with pytest.raises(SystemExit) as exc:
         load_theta(str(theta_path))
     assert exc.value.code == 2
-    assert capsys.readouterr().out.strip() == "ERROR: theta file not found"
+    assert (
+        capsys.readouterr().out.strip()
+        == f"ERROR: theta file not found: {theta_path}"
+    )
 
 
 def test_load_theta_missing_keys(tmp_path: Path) -> None:
     theta_path = tmp_path / "theta.json"
     theta_path.write_text(json.dumps({"theta0": 2.5}))
-    assert load_theta(str(theta_path)) == (2.5, 0.0)
+    assert load_theta(str(theta_path))[:2] == (2.5, 0.0)
     theta_path.write_text(json.dumps({"theta1": 3.5}))
-    assert load_theta(str(theta_path)) == (0.0, 3.5)
+    assert load_theta(str(theta_path))[:2] == (0.0, 3.5)
 
 
 @pytest.mark.parametrize(
@@ -77,3 +86,40 @@ def test_predict_price_default_theta_path(
     theta_path.write_text(json.dumps({"theta0": 1.0, "theta1": 1.0}))
     monkeypatch.chdir(tmp_path)
     assert predict_price(2.0) == pytest.approx(3.0)
+
+
+def test_load_theta_invalid_values(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    theta_path = tmp_path / "theta.json"
+    theta_path.write_text(json.dumps({"theta0": "bad"}))
+    with pytest.raises(SystemExit) as exc:
+        load_theta(str(theta_path))
+    assert exc.value.code == 2
+    assert (
+        capsys.readouterr().out.strip()
+        == f"ERROR: invalid theta values in {theta_path}"
+    )
+
+
+def test_predict_price_warns_outside_bounds(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    theta_path = tmp_path / "theta.json"
+    theta_path.write_text(
+        json.dumps(
+            {
+                "theta0": 0.0,
+                "theta1": 1.0,
+                "min_km": 0.0,
+                "max_km": 10.0,
+                "min_price": 0.0,
+                "max_price": 10.0,
+            }
+        )
+    )
+    price = predict_price(20.0, str(theta_path))
+    out = capsys.readouterr().out
+    assert price == pytest.approx(20.0)
+    assert "WARNING: mileage 20.0 outside data range [0.0, 10.0]" in out
+    assert "WARNING: price 20.0 outside data range [0.0, 10.0]" in out

--- a/tests/test_read_data.py
+++ b/tests/test_read_data.py
@@ -40,6 +40,20 @@ def test_read_data_nan_km(tmp_path: Path) -> None:
         read_data(str(bad))
 
 
+def test_read_data_negative_km(tmp_path: Path) -> None:
+    bad = tmp_path / "neg_km.csv"
+    bad.write_text("km,price\n-1,1000\n")
+    with pytest.raises(ValueError, match="invalid row 2: negative km"):
+        read_data(str(bad))
+
+
+def test_read_data_negative_price(tmp_path: Path) -> None:
+    bad = tmp_path / "neg_price.csv"
+    bad.write_text("km,price\n1,-5\n")
+    with pytest.raises(ValueError, match="invalid row 2: negative price"):
+        read_data(str(bad))
+
+
 def test_read_data_missing_value(tmp_path: Path) -> None:
     bad = tmp_path / "missing.csv"
     bad.write_text("km,price\n1000\n")


### PR DESCRIPTION
## Summary
- validate negative data and store dataset bounds during training
- ensure CLI iterations and mileage are non-negative with clear errors
- warn when predictions fall outside the training data range

## Testing
- `pytest -q`
- `python -m coverage run -m pytest && python -m coverage json && python -m coverage report --fail-under=100` *(fails: No module named coverage)*

------
https://chatgpt.com/codex/tasks/task_e_68aad306a9548324b2a191993f81a16e