### PR TITLE
fix: default to zero when theta missing

### DIFF
--- a/src/predict/predict.py
+++ b/src/predict/predict.py
@@ -54,15 +54,19 @@ def load_theta(
 ) -> tuple[float, float, float | None, float | None, float | None, float | None]:
     """Return training coefficients and data bounds from ``path``.
 
-    If the file cannot be read or contains invalid values, an error message is
-    printed and the program exits with code ``2``.
+    When ``path`` does not exist, default coefficients are returned without
+    raising an error so that predictions before training yield ``0``.  If the
+    file exists but cannot be parsed or contains invalid values, an error
+    message is printed and the program exits with code ``2``.
     """
 
     theta_path = Path(path)
+    if not theta_path.exists():
+        return 0.0, 0.0, None, None, None, None
     try:
         raw = json.loads(theta_path.read_text())
     except (OSError, json.JSONDecodeError):
-        print(f"ERROR: theta file not found: {theta_path}")
+        print(f"ERROR: invalid theta file: {theta_path}")
         raise SystemExit(2)
     try:
         theta0 = float(raw.get("theta0", 0.0))

--- a/src/predict/predict.py
+++ b/src/predict/predict.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import argparse
 import json
 from pathlib import Path
-from typing import Any, cast
+from typing import Any
 
 from linear_regression import estimatePrice
 
@@ -50,13 +50,18 @@ def parse_args(argv: list[str] | None = None) -> tuple[float, str]:
 
 def _read_theta(theta_path: Path) -> dict[str, Any]:
     try:
-        return cast(dict[str, Any], json.loads(theta_path.read_text()))
-    except (OSError, json.JSONDecodeError):
+        raw = json.loads(theta_path.read_text())
+        if not isinstance(raw, dict):
+            raise ValueError
+        return raw
+    except (OSError, json.JSONDecodeError, ValueError):
         print(f"ERROR: invalid theta file: {theta_path}")
         raise SystemExit(2)
 
 
 def _parse_float(value: Any, theta_path: Path) -> float:
+    if theta_path is None:
+        raise AssertionError
     try:
         return float(value)
     except (TypeError, ValueError):
@@ -65,6 +70,8 @@ def _parse_float(value: Any, theta_path: Path) -> float:
 
 
 def _parse_optional_float(value: Any, theta_path: Path) -> float | None:
+    if theta_path is None:
+        raise AssertionError
     return None if value is None else _parse_float(value, theta_path)
 
 

--- a/src/viz.py
+++ b/src/viz.py
@@ -6,7 +6,7 @@ import argparse
 from pathlib import Path
 from typing import Any, Iterable, cast
 
-import matplotlib.pyplot as plt
+import matplotlib.pyplot as plt  # type: ignore[import-not-found]
 
 from linear_regression import estimatePrice
 from predict.predict import load_theta

--- a/src/viz.py
+++ b/src/viz.py
@@ -6,7 +6,7 @@ import argparse
 from pathlib import Path
 from typing import Any, Iterable, cast
 
-import matplotlib.pyplot as plt  # type: ignore[import-not-found]
+import matplotlib.pyplot as plt
 
 from linear_regression import estimatePrice
 from predict.predict import load_theta

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import os
 import subprocess
 import sys
@@ -30,8 +29,6 @@ def test_predict_then_train(tmp_path: Path) -> None:
     env["PYTHONPATH"] = os.pathsep.join(
         [str(repo_root), str(repo_root / "src"), *cleaned]
     )
-
-    theta_path.write_text(json.dumps({"theta0": 0.0, "theta1": 0.0}))
 
     result_predict = subprocess.run(
         [

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -24,7 +24,7 @@ def test_load_theta_invalid_json(
         load_theta(str(theta_path))
     assert exc.value.code == 2
     assert (
-        capsys.readouterr().out.strip() == f"ERROR: theta file not found: {theta_path}"
+        capsys.readouterr().out.strip() == f"ERROR: invalid theta file: {theta_path}"
     )
 
 

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -23,9 +23,7 @@ def test_load_theta_invalid_json(
     with pytest.raises(SystemExit) as exc:
         load_theta(str(theta_path))
     assert exc.value.code == 2
-    assert (
-        capsys.readouterr().out.strip() == f"ERROR: invalid theta file: {theta_path}"
-    )
+    assert capsys.readouterr().out.strip() == f"ERROR: invalid theta file: {theta_path}"
 
 
 def test_load_theta_missing_values(tmp_path: Path) -> None:

--- a/tests/test_predict_logic.py
+++ b/tests/test_predict_logic.py
@@ -10,19 +10,13 @@ def test_load_theta_missing_and_predict(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
     theta_path = tmp_path / "theta.json"
-    with pytest.raises(SystemExit) as exc:
-        load_theta(str(theta_path))
-    assert exc.value.code == 2
-    assert (
-        capsys.readouterr().out.strip() == f"ERROR: theta file not found: {theta_path}"
-    )
+    theta0, theta1, *_ = load_theta(str(theta_path))
+    assert (theta0, theta1) == (0.0, 0.0)
+    assert capsys.readouterr().out == ""
 
-    with pytest.raises(SystemExit) as exc2:
-        predict_price(123.0, str(theta_path))
-    assert exc2.value.code == 2
-    assert (
-        capsys.readouterr().out.strip() == f"ERROR: theta file not found: {theta_path}"
-    )
+    price = predict_price(123.0, str(theta_path))
+    assert price == pytest.approx(0.0)
+    assert capsys.readouterr().out == ""
 
 
 def test_predict_price_with_file(tmp_path: Path) -> None:
@@ -43,7 +37,7 @@ def test_load_theta_invalid_json(
         load_theta(str(theta_path))
     assert exc.value.code == 2
     assert (
-        capsys.readouterr().out.strip() == f"ERROR: theta file not found: {theta_path}"
+        capsys.readouterr().out.strip() == f"ERROR: invalid theta file: {theta_path}"
     )
 
 

--- a/tests/test_predict_logic.py
+++ b/tests/test_predict_logic.py
@@ -36,9 +36,7 @@ def test_load_theta_invalid_json(
     with pytest.raises(SystemExit) as exc:
         load_theta(str(theta_path))
     assert exc.value.code == 2
-    assert (
-        capsys.readouterr().out.strip() == f"ERROR: invalid theta file: {theta_path}"
-    )
+    assert capsys.readouterr().out.strip() == f"ERROR: invalid theta file: {theta_path}"
 
 
 def test_load_theta_missing_keys(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- return default coefficients when theta file is missing so `predict` prints `0` before training
- test missing-theta workflow and update invalid theta file messages
- silence mypy import error for optional viz module

## Testing
- `poetry run ruff check .`
- `poetry run mypy src`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad7c08a7d0832483a67aa1cc73f93d