### PR TITLE
Ensure full coverage of theta parsing helpers

### DIFF
--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -3,7 +3,11 @@ from pathlib import Path
 
 import pytest
 
-from predict.predict import load_theta
+from predict.predict import (
+    _parse_float,
+    _parse_optional_float,
+    load_theta,
+)
 from train.train import save_theta
 
 
@@ -32,3 +36,27 @@ def test_load_theta_missing_values(tmp_path: Path) -> None:
     theta0, theta1, *_ = load_theta(str(theta_path))
     assert theta0 == pytest.approx(3.0)
     assert theta1 == pytest.approx(0.0)
+
+
+def test_load_theta_nondict_json(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    theta_path = tmp_path / "theta.json"
+    theta_path.write_text(json.dumps([1, 2, 3]))
+    with pytest.raises(SystemExit) as exc:
+        load_theta(str(theta_path))
+    assert exc.value.code == 2
+    assert (
+        capsys.readouterr().out.strip()
+        == f"ERROR: invalid theta file: {theta_path}"
+    )
+
+
+def test_parse_float_asserts_path() -> None:
+    with pytest.raises(AssertionError):
+        _parse_float(0.0, None)  # type: ignore[arg-type]
+
+
+def test_parse_optional_float_asserts_path() -> None:
+    with pytest.raises(AssertionError):
+        _parse_optional_float(0.0, None)  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary
- test: cover invalid theta structures and missing path errors

## Testing
- `pytest -q`
- `coverage run --branch -m pytest && coverage report --fail-under=100`


------
https://chatgpt.com/codex/tasks/task_e_68ada699813c8324a14ba97b3d7cf26e