### PR TITLE
feat: format predicted price output

### DIFF
--- a/src/predict/__main__.py
+++ b/src/predict/__main__.py
@@ -13,7 +13,7 @@ def main(argv: list[str] | None = None) -> int:  # pragma: no mutate
         price = predict_price(km, theta)
     except SystemExit as exc:  # pragma: no cover - propagate exit codes
         return exc.code if isinstance(exc.code, int) else 1  # pragma: no cover
-    print(price)
+    print(f"Predicted price: {price:.2f} €")
     return 0
 
 

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -46,7 +46,7 @@ def test_predict_then_train(tmp_path: Path) -> None:
         cwd=str(repo_root),
     )
     assert result_predict.returncode == 0
-    assert result_predict.stdout.strip() == "0.0"
+    assert result_predict.stdout.strip() == "Predicted price: 0.00 €"
 
     result_train = subprocess.run(
         [
@@ -87,7 +87,7 @@ def test_predict_then_train(tmp_path: Path) -> None:
         cwd=str(repo_root),
     )
     assert result_predict_after.returncode == 0
-    price_after = float(result_predict_after.stdout.strip().splitlines()[-1])
+    price_after = float(result_predict_after.stdout.strip().split()[-2])
     assert price_after == pytest.approx(5305.823492473339, rel=1e-2)
 
     theta_path.unlink(missing_ok=True)

--- a/tests/test_main_modules.py
+++ b/tests/test_main_modules.py
@@ -43,7 +43,7 @@ def test_predict_main_runs(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -
     theta.write_text(json.dumps({"theta0": 1.0, "theta1": 2.0}))
     assert predict_main(["--km", "3", "--theta", str(theta)]) == 0
     captured = capsys.readouterr()
-    assert float(captured.out.strip()) == pytest.approx(7.0)
+    assert captured.out.strip() == "Predicted price: 7.00 €"
 
 
 def test_predict_main_system_exit_str(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- format CLI price output with currency and 2 decimals
- adjust tests for new prediction message

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68aeeb7dbda48324bc514a187c3a54b6