### PR TITLE
feat: visualize mean and median lines

### DIFF
--- a/src/viz.py
+++ b/src/viz.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 from pathlib import Path
+from statistics import median
 from typing import Any, Iterable, cast
 
 import matplotlib.pyplot as plt
@@ -35,6 +36,12 @@ def _build_parser() -> argparse.ArgumentParser:
         action="store_true",
         default=False,
         help="display residuals as vertical lines",
+    )
+    parser.add_argument(
+        "--show-median",
+        action="store_true",
+        default=False,
+        help="display median of y as horizontal line",
     )
     return parser
 
@@ -97,6 +104,12 @@ def main(argv: list[str] | None = None) -> None:
             y_hat = estimatePrice(x, theta0, theta1)
             plt_any.vlines(x, y, y_hat, colors="gray", linewidth=0.5)
     plot_regression_line(ax, xs, theta0, theta1, args.show_eq)
+
+    mean_y = sum(ys) / len(ys)
+    plt_any.axhline(mean_y, color="blue", linestyle="--", label="mean(y)")
+    if args.show_median:
+        median_y = median(ys)
+        plt_any.axhline(median_y, color="green", linestyle=":", label="median(y)")
 
     plt_any.suptitle(f"RMSE: {rmse:.2f}, R2: {r2:.2f}")
 

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -36,6 +36,7 @@ def test_main_plots(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
         "eval": None,
         "suptitle": None,
         "vlines": 0,
+        "axhlines": [],
     }
 
     def fake_scatter(*args: object, **kwargs: object) -> None:
@@ -63,6 +64,9 @@ def test_main_plots(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     def fake_vlines(*args: object, **kwargs: object) -> None:
         calls["vlines"] += 1
 
+    def fake_axhline(y: float, *, label: str, **_: object) -> None:
+        calls["axhlines"].append((y, label))
+
     class FakeAx:
         def get_legend_handles_labels(self) -> tuple[list[object], list[str]]:
             return ([], [])
@@ -74,6 +78,7 @@ def test_main_plots(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setattr(plt, "ylabel", lambda *a, **k: None)
     monkeypatch.setattr(plt, "suptitle", fake_suptitle)
     monkeypatch.setattr(plt, "vlines", fake_vlines)
+    monkeypatch.setattr(plt, "axhline", fake_axhline)
     monkeypatch.setattr(viz, "plot_regression_line", fake_plot_reg_line)
     monkeypatch.setattr(viz, "evaluate", fake_eval)
 
@@ -90,6 +95,7 @@ def test_main_plots(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
         "eval": (str(data), str(theta)),
         "suptitle": "RMSE: 0.00, R2: 1.00",
         "vlines": 0,
+        "axhlines": [(1.0, "mean(y)")],
     }
 
     calls.update(
@@ -100,6 +106,7 @@ def test_main_plots(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
             "eval": None,
             "suptitle": None,
             "vlines": 0,
+            "axhlines": [],
         }
     )
     viz.main(
@@ -112,6 +119,7 @@ def test_main_plots(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
         "eval": (str(data), str(theta)),
         "suptitle": "RMSE: 0.00, R2: 1.00",
         "vlines": 0,
+        "axhlines": [(1.0, "mean(y)")],
     }
 
     calls.update(
@@ -122,6 +130,7 @@ def test_main_plots(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
             "eval": None,
             "suptitle": None,
             "vlines": 0,
+            "axhlines": [],
         }
     )
     viz.main(
@@ -140,6 +149,37 @@ def test_main_plots(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
         "eval": (str(data), str(theta)),
         "suptitle": "RMSE: 0.00, R2: 1.00",
         "vlines": 2,
+        "axhlines": [(1.0, "mean(y)")],
+    }
+
+    calls.update(
+        {
+            "scatter": False,
+            "plot_rl": None,
+            "show": False,
+            "eval": None,
+            "suptitle": None,
+            "vlines": 0,
+            "axhlines": [],
+        }
+    )
+    viz.main(
+        [
+            "--data",
+            str(data),
+            "--theta",
+            str(theta),
+            "--show-median",
+        ]
+    )
+    assert calls == {
+        "scatter": True,
+        "plot_rl": True,
+        "show": True,
+        "eval": (str(data), str(theta)),
+        "suptitle": "RMSE: 0.00, R2: 1.00",
+        "vlines": 0,
+        "axhlines": [(1.0, "mean(y)"), (1.0, "median(y)")],
     }
 
 


### PR DESCRIPTION
## Summary
- plot horizontal line for mean of y values
- optionally display median with `--show-median`
- exercise visual logic with tests

## Testing
- `pre-commit run --files src/viz.py tests/test_viz.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af082d264083249f2bbaee0724d8d9