### PR TITLE
feat: add confidence band option

### DIFF
--- a/src/viz.py
+++ b/src/viz.py
@@ -6,7 +6,7 @@ import argparse
 import math
 from pathlib import Path
 from statistics import NormalDist, median
-from typing import Any, Iterable, cast
+from typing import Any, Iterable, Sequence, cast
 
 import matplotlib.pyplot as plt
 
@@ -93,6 +93,60 @@ def plot_regression_line(
         )
 
 
+def plot_residuals(
+    plt_mod: Any,
+    data: Iterable[tuple[float, float]],
+    theta0: float,
+    theta1: float,
+) -> None:
+    """Display vertical lines between actual and predicted values."""
+
+    for x, y in data:
+        y_hat = estimatePrice(x, theta0, theta1)
+        plt_mod.vlines(x, y, y_hat, colors="gray", linewidth=0.5)
+
+
+def plot_confidence_band(
+    plt_mod: Any,
+    xs: Iterable[float],
+    data: Iterable[tuple[float, float]],
+    theta0: float,
+    theta1: float,
+    level: float,
+) -> None:
+    """Shade the prediction confidence band at the given level."""
+
+    xs_list = list(xs)
+    if len(xs_list) <= 2:
+        return
+    mean_x = sum(xs_list) / len(xs_list)
+    s_xx = sum((x - mean_x) ** 2 for x in xs_list)
+    residuals = [y - estimatePrice(x, theta0, theta1) for x, y in data]
+    sigma2 = sum(r**2 for r in residuals) / (len(xs_list) - 2)
+    sigma = math.sqrt(sigma2)
+    line_x = [
+        min(xs_list) + (max(xs_list) - min(xs_list)) * i / 100 for i in range(101)
+    ]
+    y_hat_band = [estimatePrice(x, theta0, theta1) for x in line_x]
+    z = NormalDist().inv_cdf(0.5 + level / 2)
+    se = [
+        sigma * math.sqrt(1 / len(xs_list) + ((x - mean_x) ** 2) / s_xx) for x in line_x
+    ]
+    lower = [y - z * e for y, e in zip(y_hat_band, se)]
+    upper = [y + z * e for y, e in zip(y_hat_band, se)]
+    plt_mod.fill_between(line_x, lower, upper, color="red", alpha=0.1)
+
+
+def plot_central_tendency(plt_mod: Any, ys: Sequence[float], show_median: bool) -> None:
+    """Draw mean and optionally median of ``ys``."""
+
+    mean_y = sum(ys) / len(ys)
+    plt_mod.axhline(mean_y, color="blue", linestyle="--", label="mean(y)")
+    if show_median:
+        median_y = median(ys)
+        plt_mod.axhline(median_y, color="green", linestyle=":", label="median(y)")
+
+
 def main(argv: list[str] | None = None) -> None:
     """Visualize the dataset and the line defined by ``theta0 + theta1 * x``."""
 
@@ -109,35 +163,11 @@ def main(argv: list[str] | None = None) -> None:
     plt_any.scatter(xs, ys, label="data")
     ax = plt_any.gca()
     if args.show_residuals:
-        for x, y in data:
-            y_hat = estimatePrice(x, theta0, theta1)
-            plt_any.vlines(x, y, y_hat, colors="gray", linewidth=0.5)
-    if args.confidence is not None and len(xs) > 2:
-        mean_x = sum(xs) / len(xs)
-        s_xx = sum((x - mean_x) ** 2 for x in xs)
-        residuals = [y - estimatePrice(x, theta0, theta1) for x, y in data]
-        sigma2 = sum(r ** 2 for r in residuals) / (len(xs) - 2)
-        sigma = math.sqrt(sigma2)
-        line_x = [
-            min(xs) + (max(xs) - min(xs)) * i / 100 for i in range(101)
-        ]
-        y_hat_band = [estimatePrice(x, theta0, theta1) for x in line_x]
-        z = NormalDist().inv_cdf(0.5 + args.confidence / 2)
-        se = [
-            sigma
-            * math.sqrt(1 / len(xs) + ((x - mean_x) ** 2) / s_xx)
-            for x in line_x
-        ]
-        lower = [y - z * e for y, e in zip(y_hat_band, se)]
-        upper = [y + z * e for y, e in zip(y_hat_band, se)]
-        plt_any.fill_between(line_x, lower, upper, color="red", alpha=0.1)
+        plot_residuals(plt_any, data, theta0, theta1)
+    if args.confidence is not None:
+        plot_confidence_band(plt_any, xs, data, theta0, theta1, args.confidence)
     plot_regression_line(ax, xs, theta0, theta1, args.show_eq)
-
-    mean_y = sum(ys) / len(ys)
-    plt_any.axhline(mean_y, color="blue", linestyle="--", label="mean(y)")
-    if args.show_median:
-        median_y = median(ys)
-        plt_any.axhline(median_y, color="green", linestyle=":", label="median(y)")
+    plot_central_tendency(plt_any, ys, args.show_median)
 
     plt_any.suptitle(f"RMSE: {rmse:.2f}, R2: {r2:.2f}")
 

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -37,6 +37,7 @@ def test_main_plots(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
         "suptitle": None,
         "vlines": 0,
         "axhlines": [],
+        "fill_between": 0,
     }
 
     def fake_scatter(*args: object, **kwargs: object) -> None:
@@ -67,6 +68,9 @@ def test_main_plots(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     def fake_axhline(y: float, *, label: str, **_: object) -> None:
         calls["axhlines"].append((y, label))
 
+    def fake_fill_between(*_: object, **__: object) -> None:
+        calls["fill_between"] += 1
+
     class FakeAx:
         def get_legend_handles_labels(self) -> tuple[list[object], list[str]]:
             return ([], [])
@@ -79,11 +83,12 @@ def test_main_plots(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setattr(plt, "suptitle", fake_suptitle)
     monkeypatch.setattr(plt, "vlines", fake_vlines)
     monkeypatch.setattr(plt, "axhline", fake_axhline)
+    monkeypatch.setattr(plt, "fill_between", fake_fill_between)
     monkeypatch.setattr(viz, "plot_regression_line", fake_plot_reg_line)
     monkeypatch.setattr(viz, "evaluate", fake_eval)
 
     data = tmp_path / "data.csv"
-    data.write_text("km,price\n0,1\n1,1\n")
+    data.write_text("km,price\n0,1\n1,1\n2,1\n")
     theta = tmp_path / "theta.json"
     theta.write_text(json.dumps({"theta0": 1.0, "theta1": 0.0}))
 
@@ -96,6 +101,7 @@ def test_main_plots(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
         "suptitle": "RMSE: 0.00, R2: 1.00",
         "vlines": 0,
         "axhlines": [(1.0, "mean(y)")],
+        "fill_between": 0,
     }
 
     calls.update(
@@ -107,6 +113,7 @@ def test_main_plots(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
             "suptitle": None,
             "vlines": 0,
             "axhlines": [],
+            "fill_between": 0,
         }
     )
     viz.main(
@@ -120,6 +127,7 @@ def test_main_plots(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
         "suptitle": "RMSE: 0.00, R2: 1.00",
         "vlines": 0,
         "axhlines": [(1.0, "mean(y)")],
+        "fill_between": 0,
     }
 
     calls.update(
@@ -131,6 +139,7 @@ def test_main_plots(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
             "suptitle": None,
             "vlines": 0,
             "axhlines": [],
+            "fill_between": 0,
         }
     )
     viz.main(
@@ -148,8 +157,9 @@ def test_main_plots(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
         "show": True,
         "eval": (str(data), str(theta)),
         "suptitle": "RMSE: 0.00, R2: 1.00",
-        "vlines": 2,
+        "vlines": 3,
         "axhlines": [(1.0, "mean(y)")],
+        "fill_between": 0,
     }
 
     calls.update(
@@ -161,6 +171,7 @@ def test_main_plots(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
             "suptitle": None,
             "vlines": 0,
             "axhlines": [],
+            "fill_between": 0,
         }
     )
     viz.main(
@@ -180,6 +191,39 @@ def test_main_plots(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
         "suptitle": "RMSE: 0.00, R2: 1.00",
         "vlines": 0,
         "axhlines": [(1.0, "mean(y)"), (1.0, "median(y)")],
+        "fill_between": 0,
+    }
+
+    calls.update(
+        {
+            "scatter": False,
+            "plot_rl": None,
+            "show": False,
+            "eval": None,
+            "suptitle": None,
+            "vlines": 0,
+            "axhlines": [],
+            "fill_between": 0,
+        }
+    )
+    viz.main(
+        [
+            "--data",
+            str(data),
+            "--theta",
+            str(theta),
+            "--confidence",
+        ]
+    )
+    assert calls == {
+        "scatter": True,
+        "plot_rl": True,
+        "show": True,
+        "eval": (str(data), str(theta)),
+        "suptitle": "RMSE: 0.00, R2: 1.00",
+        "vlines": 0,
+        "axhlines": [(1.0, "mean(y)")],
+        "fill_between": 1,
     }
 
 


### PR DESCRIPTION
## Summary
- allow `viz.py` to display confidence bands with `--confidence` option
- compute OLS-based residual variance and prediction standard error for shading
- test confidence band rendering via `plt.fill_between`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af17a7c3c88324a24aeaa3d6c3a9e0