### PR TITLE
feat: highlight residual outliers

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ Tout écart (crash, valeur incohérente, absence de 0 en étape A, MAJ non simul
 poetry run python -m src.viz --data data.csv --theta theta.json --show-residuals
 ```
 Ajoutez `--show-residuals` pour tracer des lignes verticales représentant les résidus.
+Utilisez `--sigma-k` (défaut `2`) pour colorer en orange les points dont
+`|résidu| > k·σ`; ils sont ajoutés à la légende sous le nom « outliers ».
 <p align="center">
   <img src="docs/price-vs-km-regression.png" alt="Régression linéaire (price vs km)" width="760">
   <br><em>Nuage de points et droite θ₀ + θ₁·x (après entraînement).</em>


### PR DESCRIPTION
## Summary
- detect outliers using residual standard deviation and configurable `--sigma-k`
- plot flagged points in orange and label them as outliers
- document sigma-based highlighting and cover with tests

## Testing
- `pre-commit run --files README.md src/viz.py tests/test_viz.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af1d0305908324ae07ef63aea5e9f9