### PR TITLE
fix: reject extra arguments for make predict

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,14 @@ train:
 # Prédiction du prix pour une valeur donnée (km)
 predict: KM := $(word 2, $(MAKECMDGOALS))
 predict:
+	@if [ $(words $(MAKECMDGOALS)) -gt 2 ]; then \
+		echo "ERROR: Too many arguments"; \
+		echo "Usage:"; \
+		echo "  make predict            # interactive"; \
+		echo "  make predict <km>       # direct prediction"; \
+		echo "  make train              # train the model"; \
+		exit 2; \
+	fi; \
 	$(POETRY) predict --theta $(THETA) $(if $(KM),--km $(KM),)
 
 # Visualisation des données + droite (theta0 + theta1 * x)

--- a/tests/test_main_modules.py
+++ b/tests/test_main_modules.py
@@ -46,6 +46,16 @@ def test_predict_main_runs(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -
     assert captured.out.strip() == "Predicted price: 7.00 €"
 
 
+def test_predict_main_prints_zero(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    theta = tmp_path / "theta.json"
+    theta.write_text(json.dumps({"theta0": 0.0, "theta1": 0.0}))
+    assert predict_main(["--km", "0", "--theta", str(theta)]) == 0
+    captured = capsys.readouterr()
+    assert captured.out.strip() == "0"
+
+
 def test_predict_main_system_exit_str(monkeypatch: pytest.MonkeyPatch) -> None:
     def fake_parse_args(_argv: list[str] | None = None) -> tuple[float, str]:
         raise SystemExit("boom")


### PR DESCRIPTION
## Summary
- prevent `make predict` from running when provided more than one positional argument
- display clear usage instructions for predict and train commands

## Testing
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b03aec54b8832495a83a5c0339c9c6