### PR TITLE
test: strengthen predict main theta handling

### DIFF
--- a/tests/test_main_modules.py
+++ b/tests/test_main_modules.py
@@ -64,6 +64,16 @@ def test_predict_main_system_exit_str(monkeypatch: pytest.MonkeyPatch) -> None:
     assert predict_main([]) == 1
 
 
+def test_predict_main_non_string_theta(monkeypatch: pytest.MonkeyPatch) -> None:
+    from pathlib import Path
+
+    def fake_parse_args(_argv: list[str] | None = None) -> tuple[float, Path]:
+        return 1.0, Path("theta.json")
+
+    monkeypatch.setattr("predict.__main__.parse_args", fake_parse_args)
+    assert predict_main([]) == 2
+
+
 def test_train_main_missing_csv(capsys: pytest.CaptureFixture[str]) -> None:
     code = train_main(["--data", "missing.csv"])
     captured = capsys.readouterr()


### PR DESCRIPTION
## Summary
- add regression test for non-string theta in `predict.main`

## Testing
- `poetry run ruff check .`
- `poetry run mypy src`
- `poetry run pytest -q`
- `poetry run mutmut run`


------
https://chatgpt.com/codex/tasks/task_e_68b1a2698e60832495bdb22ff7f2d2ee