### PR TITLE
fix: format predict module

### DIFF
--- a/src/predict/predict.py
+++ b/src/predict/predict.py
@@ -29,7 +29,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     # Rend l’argument km optionnel pour supporter le mode interactif.
     parser.add_argument("km", nargs="?", type=float, help="mileage in kilometers")
-    # Permet de choisir une autre source de coefficients sans recompilation.    
+    # Permet de choisir une autre source de coefficients sans recompilation.
     parser.add_argument("--theta", default="theta.json", help="path to theta JSON")
     # Retourne le parseur pour réutilisation dans parse_args().
     return parser
@@ -58,7 +58,7 @@ def _prompt_mileage() -> float:
 
 
 def parse_args(argv: list[str] | None = None) -> tuple[float, str]:
-    """ Centralise le parsing et la politique d’entrée pour cohérence CLI."""
+    """Centralise le parsing et la politique d’entrée pour cohérence CLI."""
     # Construit le parseur une seule fois pour config unique de la CLI.
     parser = build_parser()
     # Permet d’ignorer des arguments inconnus et de les contrôler ensuite.


### PR DESCRIPTION
## Summary
- apply black formatting to src/predict/predict.py so pre-commit passes

## Testing
- `poetry run pre-commit run --all-files`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3156857048324af9e3bb8e1bad2e4